### PR TITLE
Inline reply

### DIFF
--- a/lib/src/main/java/com/sshtools/twoslices/ToastBuilder.java
+++ b/lib/src/main/java/com/sshtools/twoslices/ToastBuilder.java
@@ -43,6 +43,9 @@ public class ToastBuilder {
 		private String label;
 		private String icon;
 		private ToastActionListener listener;
+		private boolean input;
+		private String prompt;
+		private ToastReplyListener replyListener;
 
 		ToastAction(String name) {
 			this(name, name);
@@ -125,6 +128,69 @@ public class ToastBuilder {
 		 */
 		public ToastActionListener listener() {
 			return listener;
+		}
+
+		/**
+		 * Get whether this action presents an inline text input / reply field.
+		 * Only honoured by toasters with {@link Capability#INPUT}.
+		 *
+		 * @return input
+		 */
+		public boolean input() {
+			return input;
+		}
+
+		/**
+		 * Set whether this action presents an inline text input / reply field.
+		 *
+		 * @param input input
+		 * @return this for chaining
+		 */
+		public ToastAction input(boolean input) {
+			this.input = input;
+			return this;
+		}
+
+		/**
+		 * Get the prompt (placeholder) text shown in an {@link #input()} field.
+		 *
+		 * @return prompt
+		 */
+		public String prompt() {
+			return prompt;
+		}
+
+		/**
+		 * Set the prompt (placeholder) text shown in an {@link #input()} field.
+		 *
+		 * @param prompt prompt
+		 * @return this for chaining
+		 */
+		public ToastAction prompt(String prompt) {
+			this.prompt = prompt;
+			return this;
+		}
+
+		/**
+		 * Get the reply listener invoked with the typed text for an
+		 * {@link #input()} action.
+		 *
+		 * @return reply listener
+		 */
+		public ToastReplyListener replyListener() {
+			return replyListener;
+		}
+
+		/**
+		 * Set the reply listener invoked with the typed text for an
+		 * {@link #input()} action.
+		 *
+		 * @param replyListener reply listener
+		 * @return this for chaining
+		 */
+		public ToastAction replyListener(ToastReplyListener replyListener) {
+			this.replyListener = replyListener;
+			return this;
 		}
 
 		/**
@@ -482,6 +548,22 @@ public class ToastBuilder {
 	 */
 	public ToastBuilder action(String name, String label, ToastActionListener listener) {
 		newAction(name).label(label).listener(listener);
+		return this;
+	}
+
+	/**
+	 * Convenience method to add an inline reply / text input action. Only
+	 * honoured by toasters that have {@link Capability#INPUT}; other toasters
+	 * will treat it as (or ignore it like) an ordinary action.
+	 *
+	 * @param name     name
+	 * @param label    label
+	 * @param prompt   prompt (placeholder) text, may be <code>null</code>
+	 * @param listener reply listener invoked with the typed text
+	 * @return this for chaining
+	 */
+	public ToastBuilder input(String name, String label, String prompt, ToastReplyListener listener) {
+		newAction(name).label(label).input(true).prompt(prompt).replyListener(listener);
 		return this;
 	}
 

--- a/lib/src/main/java/com/sshtools/twoslices/ToastReplyListener.java
+++ b/lib/src/main/java/com/sshtools/twoslices/ToastReplyListener.java
@@ -16,26 +16,17 @@
 package com.sshtools.twoslices;
 
 /**
- * For querying capabilities a {@link Toaster} has.
+ * Interface defining the callback invoked when the user submits text into an
+ * inline reply / input field on a notification. Only toasters that have
+ * {@link Capability#INPUT} support this; on others an input action behaves as
+ * (or is ignored like) an ordinary action.
  */
-public enum Capability {
-
+@FunctionalInterface
+public interface ToastReplyListener {
 	/**
-	 * Supports multiple actions (likely limited)
+	 * Called when the user submits an inline reply.
+	 *
+	 * @param text the text the user entered
 	 */
-	ACTIONS,
-	/**
-	 * Supports a default action (e.g. clicking the message)
-	 */
-	DEFAULT_ACTION,
-	/**
-	 * Messages can be closed programmatically via {@link Slice#close()}.
-	 */
-	CLOSE, IMAGES,
-	/**
-	 * Supports an inline text reply / input field on a notification. The text
-	 * the user types is delivered to a {@link ToastReplyListener} set on an
-	 * input action (see {@link ToastBuilder#input}).
-	 */
-	INPUT
+	void reply(String text);
 }

--- a/lib/src/main/java/com/sshtools/twoslices/impl/DBUSNotifyToaster.java
+++ b/lib/src/main/java/com/sshtools/twoslices/impl/DBUSNotifyToaster.java
@@ -42,6 +42,7 @@ import com.sshtools.twoslices.Slice;
 import com.sshtools.twoslices.ToastActionListener;
 import com.sshtools.twoslices.ToastBuilder;
 import com.sshtools.twoslices.ToastBuilder.ToastAction;
+import com.sshtools.twoslices.ToastReplyListener;
 import com.sshtools.twoslices.Toaster;
 import com.sshtools.twoslices.ToasterService;
 import com.sshtools.twoslices.ToasterSettings;
@@ -111,17 +112,42 @@ public class DBUSNotifyToaster extends AbstractToaster {
 
 		}
 
+		@Reflectable
+		@TypeReflect(methods = true, constructors = true)
+		public class NotificationReplied extends DBusSignal {
+
+			private UInt32 id;
+			private String text;
+
+			public NotificationReplied(String path, UInt32 id, String text) throws DBusException {
+				super(path);
+				this.id = id;
+				this.text = text;
+			}
+
+			public UInt32 getId() {
+				return id;
+			}
+
+			public String getText() {
+				return text;
+			}
+
+		}
+
 	}
 
 	private DBusConnection conn;
 	private Notifications notifications;
 	private Map<UInt32, ActiveNotification> actives = new HashMap<>();
+	private boolean inlineReplySupported;
 
 	class ActiveNotification implements Slice {
 		List<ToastAction> actions;
 		ToastAction defaultAction;
 		UInt32 id;
 		ToastActionListener closed;
+		ToastReplyListener replyListener;
 		public boolean destroyed;
 		Set<Path> tempImagePath = new LinkedHashSet<>();
 		
@@ -153,6 +179,26 @@ public class DBUSNotifyToaster extends AbstractToaster {
 
 			notifications = conn.getRemoteObject("org.freedesktop.Notifications", "/org/freedesktop/Notifications",
 					Notifications.class);
+
+			try {
+				var caps = notifications.GetCapabilities();
+				if (caps != null && Arrays.asList(caps).contains("inline-reply")) {
+					inlineReplySupported = true;
+					capabilities.add(Capability.INPUT);
+				}
+			} catch (RuntimeException e) {
+				/* server does not advertise capabilities; assume no inline reply */
+			}
+
+			conn.addSigHandler(Notifications.NotificationReplied.class, notifications, (s) -> {
+				ActiveNotification active;
+				synchronized (actives) {
+					active = actives.get(s.id);
+				}
+				if (active != null && active.replyListener != null) {
+					active.replyListener.reply(s.text);
+				}
+			});
 
 			conn.addSigHandler(Notifications.ActionInvoked.class, notifications, (s) -> {
 				ActiveNotification active = null;
@@ -249,9 +295,20 @@ public class DBUSNotifyToaster extends AbstractToaster {
 			actions.add("default");
 			actions.add(builder.defaultAction().displayName());
 		}
+		ToastReplyListener replyListener = null;
 		for (var a : toastActions) {
-			actions.add(a.name());
-			actions.add(a.displayName());
+			if (a.input()) {
+				if (inlineReplySupported) {
+					/* freedesktop inline-reply: the action key must be "inline-reply" */
+					actions.add("inline-reply");
+					actions.add(a.displayName());
+					replyListener = a.replyListener();
+				}
+				/* else: server has no inline-reply, omit rather than show a dead button */
+			} else {
+				actions.add(a.name());
+				actions.add(a.displayName());
+			}
 		}
 		var active = new ActiveNotification();
 		active.tempImagePath.addAll(tempImagePaths);
@@ -266,6 +323,7 @@ public class DBUSNotifyToaster extends AbstractToaster {
 		active.actions = toastActions;
 		active.closed = builder.closed();
 		active.defaultAction = builder.defaultAction();
+		active.replyListener = replyListener;
 		
 		this.actives.put(active.id, active);
 		

--- a/lib/src/main/java/com/sshtools/twoslices/impl/NotificationCenterToaster.java
+++ b/lib/src/main/java/com/sshtools/twoslices/impl/NotificationCenterToaster.java
@@ -26,12 +26,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.sshtools.twoslices.AbstractToaster;
 import com.sshtools.twoslices.BasicToastHint;
 import com.sshtools.twoslices.Capability;
 import com.sshtools.twoslices.Slice;
+import com.sshtools.twoslices.ToastActionListener;
 import com.sshtools.twoslices.ToastBuilder;
+import com.sshtools.twoslices.ToastReplyListener;
 import com.sshtools.twoslices.ToastType;
 import com.sshtools.twoslices.Toaster;
 import com.sshtools.twoslices.ToasterService;
@@ -879,7 +882,7 @@ public class NotificationCenterToaster extends AbstractToaster {
 		if(osVersion.compareTo(minVersion) < 0) {
 			throw new UnsupportedOperationException();
 		}
-		capabilities.addAll(Arrays.asList(Capability.IMAGES, Capability.ACTIONS, Capability.CLOSE));
+		capabilities.addAll(Arrays.asList(Capability.IMAGES, Capability.ACTIONS, Capability.CLOSE, Capability.DEFAULT_ACTION, Capability.INPUT));
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			@Override
 			public void run() {
@@ -900,27 +903,121 @@ public class NotificationCenterToaster extends AbstractToaster {
 		Foundation.invoke(notification, "setInformativeText:",
 				Foundation.nsString(StringUtil.stripHtml(builder.content(), true).replace("%", "%%")));
 		
-		var actions = builder.actions();
-		if(actions.size() > 0) {
-			Foundation.invoke(notification, "setHasActionButton:", true);	
+		installDelegate();
+		var buttonActions = new ArrayList<ToastBuilder.ToastAction>();
+		ToastBuilder.ToastAction inputAction = null;
+		for (var a : builder.actions()) {
+			if (a.input() && inputAction == null)
+				inputAction = a;
+			else
+				buttonActions.add(a);
+		}
+		if (!buttonActions.isEmpty()) {
+			Foundation.invoke(notification, "setHasActionButton:", true);
 			Foundation.invoke(notification, "setActionButtonTitle:",
-					Foundation.nsString(actions.get(0).displayName()));	
-			if(actions.size() > 1) {
+					Foundation.nsString(buttonActions.get(0).displayName()));
+			if (buttonActions.size() > 1) {
 				Foundation.invoke(notification, "setOtherButtonTitle:",
-						Foundation.nsString(actions.get(1).displayName()));
+						Foundation.nsString(buttonActions.get(1).displayName()));
 			}
 		}
-		
+		if (inputAction != null) {
+			Foundation.invoke(notification, "setHasReplyButton:", true);
+			if (inputAction.prompt() != null)
+				Foundation.invoke(notification, "setResponsePlaceholder:", Foundation.nsString(inputAction.prompt()));
+		}
+
+		var id = UUID.randomUUID().toString();
+		Foundation.invoke(notification, "setIdentifier:", Foundation.nsString(id));
+		var listeners = new ActiveListeners();
+		listeners.buttonActions = buttonActions;
+		listeners.defaultAction = builder.defaultAction();
+		listeners.replyListener = inputAction == null ? null : inputAction.replyListener();
+		listeners.closed = builder.closed();
+		listenersById.put(id, listeners);
+
 		final ID center = Foundation.invoke(Foundation.getObjcClass("NSUserNotificationCenter"),
 				"defaultUserNotificationCenter");
 		Foundation.invoke(center, "deliverNotification:", notification);
-		
+
 		return new Slice() {
 			@Override
 			public void close() throws IOException {
-				Foundation.invoke(notification, "removeDeliveredNotification:", notification);	
+				listenersById.remove(id);
+				Foundation.invoke(center, "removeDeliveredNotification:", notification);
 			}
 		};
+	}
+
+	private static final Map<String, ActiveListeners> listenersById = new ConcurrentHashMap<>();
+	private static Callback delegateCallback;
+	private static ID delegateInstance;
+	private static final Object DELEGATE_LOCK = new Object();
+
+	private static class ActiveListeners {
+		List<ToastBuilder.ToastAction> buttonActions = Collections.emptyList();
+		ToastBuilder.ToastAction defaultAction;
+		ToastReplyListener replyListener;
+		ToastActionListener closed;
+	}
+
+	private static void installDelegate() {
+		synchronized (DELEGATE_LOCK) {
+			if (delegateInstance != null)
+				return;
+			var delegateClass = Foundation.allocateObjcClassPair(Foundation.getObjcClass("NSObject"),
+					"TwoSlicesUserNotificationDelegate");
+			Foundation.registerObjcClassPair(delegateClass);
+			var cb = new Callback() {
+				@SuppressWarnings("unused")
+				public void callback(ID self, String selector, ID center, ID notification) {
+					handleActivation(notification);
+				}
+			};
+			if (!Foundation.addMethod(delegateClass,
+					Foundation.createSelector("userNotificationCenter:didActivateNotification:"), cb, "v@:@@")) {
+				throw new RuntimeException("Unable to add delegate method to TwoSlicesUserNotificationDelegate");
+			}
+			delegateCallback = cb;
+			delegateInstance = Foundation.invoke(Foundation.invoke(delegateClass, "alloc"), "init");
+			var center = Foundation.invoke(Foundation.getObjcClass("NSUserNotificationCenter"),
+					"defaultUserNotificationCenter");
+			Foundation.invoke(center, "setDelegate:", delegateInstance);
+		}
+	}
+
+	private static void handleActivation(ID notification) {
+		try {
+			var id = Foundation.toStringViaUTF8(Foundation.invoke(notification, "identifier"));
+			if (id == null)
+				return;
+			var listeners = listenersById.remove(id);
+			if (listeners == null)
+				return;
+			var activationType = Foundation.invoke(notification, "activationType").intValue();
+			switch (activationType) {
+			case 1: /* NSUserNotificationActivationTypeContentsClicked */
+				if (listeners.defaultAction != null && listeners.defaultAction.listener() != null)
+					listeners.defaultAction.listener().action();
+				break;
+			case 2: /* NSUserNotificationActivationTypeActionButtonClicked */
+				if (!listeners.buttonActions.isEmpty() && listeners.buttonActions.get(0).listener() != null)
+					listeners.buttonActions.get(0).listener().action();
+				break;
+			case 3: /* NSUserNotificationActivationTypeReplied */
+				if (listeners.replyListener != null) {
+					var text = Foundation.toStringViaUTF8(Foundation.invoke(Foundation.invoke(notification, "response"), "string"));
+					listeners.replyListener.reply(text == null ? "" : text);
+				}
+				break;
+			default:
+				break;
+			}
+			if (listeners.closed != null)
+				listeners.closed.action();
+		} catch (Throwable t) {
+			/* never let an exception cross the native callback boundary */
+		}
 	}
 
 	private static void cleanupDeliveredNotifications() {

--- a/lib/src/test/java/com/sshtools/twoslices/ToastBuilderInputTest.java
+++ b/lib/src/test/java/com/sshtools/twoslices/ToastBuilderInputTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2018 SSHTOOLS Limited (support@sshtools.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sshtools.twoslices;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.sshtools.twoslices.ToastBuilder.ToastAction;
+
+/**
+ * Unit tests for the inline reply / input action API surface on
+ * {@link ToastBuilder}. These are pure and do not display a notification.
+ */
+public class ToastBuilderInputTest {
+
+	@Test
+	public void inputActionStoresPromptAndReplyListener() {
+		var got = new AtomicReference<String>();
+		var builder = new ToastBuilder()
+				.title("Title")
+				.content("Body")
+				.input("reply", "Reply", "Message", got::set);
+
+		assertEquals(1, builder.actions().size());
+		ToastAction a = builder.actions().get(0);
+		assertEquals("reply", a.name());
+		assertEquals("Reply", a.label());
+		assertTrue(a.input());
+		assertEquals("Message", a.prompt());
+
+		a.replyListener().reply("hello");
+		assertEquals("hello", got.get());
+	}
+
+	@Test
+	public void ordinaryActionIsNotInput() {
+		var builder = new ToastBuilder().action("ok", "OK", () -> {
+		});
+		ToastAction a = builder.actions().get(0);
+		assertFalse(a.input());
+		assertNull(a.prompt());
+		assertNull(a.replyListener());
+	}
+}


### PR DESCRIPTION
notification systems (and messaging apps that use them) support replying to a message directly from the notification. two-slices had no way to express this. This adds a small, opt-in API and wires it into the backends that can host it. Adds support for inline text replies in notifications. Implemented for the platforms whose notification systems support it (Linux via the freedesktop `inline-reply` capability, macOS via `NSUserNotification`), with graceful degradation everywhere else.

A caller can check support with `Toast.builder().toast(...)`'s toaster, or
`ToasterFactory.getFactory().toaster().capabilities().contains(Capability.INPUT)`.

Backend support:

- `DBUSNotifyToaster` (linux): works; when the notification server advertises the `inline-reply` capability (e.g. KDE Plasma). Detected via `GetCapabilities()`; the reply text arrives on the `NotificationReplied` signal. If unsupported, the input action is omitted rather than shown as a dead button. |
- `NotificationCenterToaster` (macOS)| works, via `NSUserNotification` `hasReplyButton` + `responsePlaceholder`. A new `NSUserNotificationCenter` delegate dispatches `didActivateNotification` (also fixes action-button clicks never invoking their listeners).
- AWT / JavaFX / SWT / `OsXToaster` (osascript) / GNTP / Growl / SysOut, do not have input capability.

- Linux inline-reply availability depends on the notification server.

p.s running `NotificationCenterToaster` under the module path fails because the `impl` package is not opened to `com.sun.jna` for reflection (the macOS toaster never worked under JPMS). Classpath usage is unaffected. Happy to address this separately if desired.

